### PR TITLE
Fix offset for pylint result

### DIFF
--- a/python_lint.py
+++ b/python_lint.py
@@ -186,7 +186,7 @@ def pylint_format_sarif(results: List[Dict[str, Any]], target: Path) -> dict:
         start_line = int(result["line"])
         start_column = int(result["column"]) + 1
         end_line = int(result["endLine"]) if result["endLine"] is not None else int(result["line"])
-        end_column = int(result["endColumn"]) if result["endColumn"] is not None else int(result["column"]) + 1
+        end_column = int(result["endColumn"]) + 1 if result["endColumn"] is not None else int(result["column"]) + 1
 
         # append result to SARIF
         sarif_result = {


### PR DESCRIPTION
Hi 👋 . I just tested this action with `pylint`. The scanning is successfully completed, but it seems the last character is not highlighted. I am wondering if `endColumn` needs to have `+1` offset as similar as `column`.

## Notes
### Before Change
<img width="300" alt="image" src="https://github.com/aegilops/python-lint-code-scanning-action/assets/1172471/e7306f5a-06f2-4fef-9f4e-a0e0dfe69372">

### After Change
<img width="300" alt="image" src="https://github.com/aegilops/python-lint-code-scanning-action/assets/1172471/9dabc244-4653-4470-b71c-24627aeaae0a">

## Tested Workflow

```yaml
name: Python Linter
on:
  push:
    branches: [ "main" ]
  pull_request:
    branches: [ "main" ]
jobs:
  lint:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Run Python Lint
        uses: aegilops/python-lint-code-scanning-action@v0.0.1
        with:
          linter: pylint
```